### PR TITLE
Move telegram to http.client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/conn_bot.py
+++ b/conn_bot.py
@@ -19,13 +19,23 @@ node_info = ""
 
 def send(status):
     if cfg.publish_telegram: # Send telegram message
-        cmd = 'curl -s "https://api.telegram.org/bot' + cfg.telegram_keys["apikey"] + "/sendmessage?chat_id=" + cfg.telegram_keys["chat_id"] + "&text=" + status +'"'
-        os.system(cmd)
+        conn = http.client.HTTPSConnection("api.telegram.org")
+        url = f"/bot{cfg.telegram_keys['apikey']}/sendMessage"
+        payload = {
+            "chat_id": cfg.telegram_keys["chat_id"],
+            "text": status
+        }
+        payload_json = json.dumps(payload)
+        headers = {
+            "Content-Type": "application/json"
+        }
+        conn.request("POST", url, body=payload_json, headers=headers)
+        conn.getresponse()
 
     if cfg.publish_discord: # Send Status to Discord
         for wh in cfg.discord_wh_url:
             webhook = DiscordWebhook(url=wh, content=status)
-            response = webhook.execute() 
+            response = webhook.execute()
 
     if cfg.publish_pushover: # Send Status to Pushover
         conn = http.client.HTTPSConnection("api.pushover.net:443")
@@ -80,12 +90,12 @@ else:
             status = status + " connected to "
         else:
             status = status + " disconnected from "
-        
+
         if my_node == cfg.echolink_node:
             status = status + "Echolink (" + str(my_node) + ")"
         else:
             status = status + str(my_node)
-        
+
         # send message
         status = status + " at " + now.strftime("%H:%M:%S")
         send(status)


### PR DESCRIPTION
I found the `curl -s` command didn't work, and I was going to change it to a `curl -X POST ` one but then figured why not use http.client like the pushover client.

Also added a python gitignore (from [Github](https://github.com/github/gitignore/blob/main/Python.gitignore))